### PR TITLE
Add Spotify search and playback controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,9 +3,11 @@ import sqlite3
 from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.utils import secure_filename
 import json
-from datetime import date, datetime,timedelta
+from datetime import date, datetime, timedelta
 import os
-import pygame 
+import pygame
+import requests
+import base64
 
 
 
@@ -509,12 +511,7 @@ def vote():
 def music():
     if 'user' not in session:
         return redirect('/login')
-    can_add = session.get('role') in ['admin', 'purple']
-    with sqlite3.connect('database.db', check_same_thread=False) as conn:
-        cur = conn.cursor()
-        cur.execute('SELECT id, title FROM songs')
-        songs = cur.fetchall()
-    return render_template('music.html', songs=songs, can_add=can_add)
+    return render_template('music.html')
 
 
 @app.route('/upload_music', methods=['POST'])
@@ -553,6 +550,116 @@ def play_music():
         except Exception as e:
             print(f'Error playing music: {e}')
     return redirect('/music')
+
+
+# --- SPOTIFY INTEGRATION ---
+def get_spotify_token():
+    """Fetch a fresh Spotify access token using a refresh token."""
+    client_id = os.environ.get('SPOTIFY_CLIENT_ID')
+    client_secret = os.environ.get('SPOTIFY_CLIENT_SECRET')
+    refresh_token = os.environ.get('SPOTIFY_REFRESH_TOKEN')
+    if not all([client_id, client_secret, refresh_token]):
+        return None
+    auth_str = f"{client_id}:{client_secret}"
+    b64_auth = base64.b64encode(auth_str.encode()).decode()
+    response = requests.post(
+        'https://accounts.spotify.com/api/token',
+        data={'grant_type': 'refresh_token', 'refresh_token': refresh_token},
+        headers={'Authorization': f'Basic {b64_auth}'},
+        timeout=10,
+    )
+    if response.status_code != 200:
+        return None
+    return response.json().get('access_token')
+
+
+@app.route('/spotify_search')
+def spotify_search():
+    if 'user' not in session:
+        return redirect('/login')
+    query = request.args.get('q', '')
+    token = get_spotify_token()
+    if not token or not query:
+        return {'tracks': []}
+    response = requests.get(
+        'https://api.spotify.com/v1/search',
+        params={'q': query, 'type': 'track', 'limit': 10},
+        headers={'Authorization': f'Bearer {token}'},
+        timeout=10,
+    )
+    data = response.json()
+    tracks = []
+    for item in data.get('tracks', {}).get('items', []):
+        tracks.append({
+            'name': item['name'],
+            'artist': item['artists'][0]['name'],
+            'uri': item['uri'],
+        })
+    return {'tracks': tracks}
+
+
+@app.route('/spotify_play', methods=['POST'])
+def spotify_play():
+    if 'user' not in session:
+        return redirect('/login')
+    data = request.get_json(silent=True) or {}
+    uri = data.get('uri')
+    token = get_spotify_token()
+    if not token or not uri:
+        return ('', 400)
+    device_id = os.environ.get('SPOTIFY_DEVICE_ID')
+    params = {'device_id': device_id} if device_id else None
+    requests.put(
+        'https://api.spotify.com/v1/me/player/play',
+        params=params,
+        json={'uris': [uri]},
+        headers={'Authorization': f'Bearer {token}'},
+        timeout=10,
+    )
+    return ('', 204)
+
+
+@app.route('/spotify_queue', methods=['POST'])
+def spotify_queue():
+    if 'user' not in session:
+        return redirect('/login')
+    data = request.get_json(silent=True) or {}
+    uri = data.get('uri')
+    token = get_spotify_token()
+    if not token or not uri:
+        return ('', 400)
+    requests.post(
+        'https://api.spotify.com/v1/me/player/queue',
+        params={'uri': uri},
+        headers={'Authorization': f'Bearer {token}'},
+        timeout=10,
+    )
+    return ('', 204)
+
+
+@app.route('/spotify_control', methods=['POST'])
+def spotify_control():
+    if 'user' not in session:
+        return redirect('/login')
+    data = request.get_json(silent=True) or {}
+    action = data.get('action')
+    token = get_spotify_token()
+    if not token or not action:
+        return ('', 400)
+    headers = {'Authorization': f'Bearer {token}'}
+    device_id = os.environ.get('SPOTIFY_DEVICE_ID')
+    params = {'device_id': device_id} if device_id else None
+    if action == 'pause':
+        requests.put('https://api.spotify.com/v1/me/player/pause', params=params, headers=headers, timeout=10)
+    elif action == 'play':
+        requests.put('https://api.spotify.com/v1/me/player/play', params=params, headers=headers, timeout=10)
+    elif action == 'next':
+        requests.post('https://api.spotify.com/v1/me/player/next', params=params, headers=headers, timeout=10)
+    elif action == 'previous':
+        requests.post('https://api.spotify.com/v1/me/player/previous', params=params, headers=headers, timeout=10)
+    else:
+        return ('', 400)
+    return ('', 204)
 
 
 

--- a/templates/music.html
+++ b/templates/music.html
@@ -1,32 +1,64 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Music Player</title>
+    <title>Spotify Player</title>
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
 <div class="box">
-    <h2>Music Player</h2>
-    {% if can_add %}
-    <form method="POST" action="/upload_music" enctype="multipart/form-data">
-        <input type="file" name="file" accept="audio/*" required>
-        <input type="text" name="title" placeholder="Title" required>
-        <button type="submit">Upload</button>
-    </form>
-    {% endif %}
+    <h2>Spotify Player</h2>
+    <input type="text" id="searchQuery" placeholder="Search for a song">
+    <button onclick="search()">Search</button>
+    <ul id="results" class="grocery-list"></ul>
 
-    <ul class="grocery-list">
-        {% for song in songs %}
-        <li>
-            {{ song[1] }}
-            <form method="POST" action="/play_music" style="display:inline;">
-                <input type="hidden" name="song_id" value="{{ song[0] }}">
-                <button type="submit">Play</button>
-            </form>
-        </li>
-        {% endfor %}
-    </ul>
+    <div id="controls">
+        <button onclick="control('previous')">Prev</button>
+        <button onclick="control('play')">Play</button>
+        <button onclick="control('pause')">Pause</button>
+        <button onclick="control('next')">Next</button>
+    </div>
     <a class="button" href="/dashboard">Back</a>
 </div>
+
+<script>
+function search() {
+    const q = document.getElementById('searchQuery').value;
+    fetch('/spotify_search?q=' + encodeURIComponent(q))
+      .then(r => r.json())
+      .then(data => {
+          const ul = document.getElementById('results');
+          ul.innerHTML = '';
+          data.tracks.forEach(track => {
+              const li = document.createElement('li');
+              li.textContent = track.name + ' - ' + track.artist + ' ';
+              const playBtn = document.createElement('button');
+              playBtn.textContent = 'Play';
+              playBtn.onclick = () => fetch('/spotify_play', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ uri: track.uri })
+              });
+              const queueBtn = document.createElement('button');
+              queueBtn.textContent = 'Queue';
+              queueBtn.onclick = () => fetch('/spotify_queue', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ uri: track.uri })
+              });
+              li.appendChild(playBtn);
+              li.appendChild(queueBtn);
+              ul.appendChild(li);
+          });
+      });
+}
+
+function control(action) {
+    fetch('/spotify_control', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action })
+    });
+}
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate Spotify Web API for searching, playing, queueing, and controlling tracks
- replace music page with Spotify search and player controls

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688b9834aee0833180ba068fe6386146